### PR TITLE
公有云安装教程完善

### DIFF
--- a/adminmanual/install/aliyun.md
+++ b/adminmanual/install/aliyun.md
@@ -1,41 +1,37 @@
+# 在阿里云上安装 Lain
 
-# 在阿里云上安装Lain
+## 机器选型
 
-## bootstrap
+- 网络类型使用*专有网络*
+  - 专有网络创建:
+
+    TODO
+
+- 安全组创建
+
+  TODO
+
+- 修改 hostname。如 `hostname lain-01`(重新登录)
+
+## Bootstrap
 
 ```sh
 # @lain-01
-
-# 修改 hostname
-hostname lain-01 # 修改后需退出重新登录ssh，才可看到效果。
-
 git clone git@github.com/laincloud/lain.git lain
-
 cd lain
-
 # DOMAIN 默认值是 lain.local
 ./bootstrap -r registry.aliyuncs.com/laincloud --ipip --domain DOMAIN
 ```
 
-## add node
+## Add node (optional)
 
 ```sh
-# 同 lain-01 一样修改下 新节点的 hostname
-
 # @lain-01
 lainctl node add -p playbooks -q lain-02:NODEIP
 ```
 
-## 导入外网流量
+## Scale webrouter
 
-aliyun 控制台开启 elb 实例
+参见 [webrouter scale](../maintain/webrouter.html#scale)
 
-随便华北 A或者B区开一个外网 负载均衡
-
-配置端口监听以及后端服务器
-
-## scale webrouter
-
-参见 [webrouter scale](../maintain/webrouter.html)
-
-webrouter 扩容后，集群有两个外界入口，可使用阿里云的 ELB 引入外部流量。并将自己的域名解析到 ELB 上。
+webrouter 扩容后，集群有两个外界入口(80 和 443 端口)，可使用阿里云的 ELB 引入外部流量。并将自己的域名解析到 ELB 上。

--- a/adminmanual/install/aws.md
+++ b/adminmanual/install/aws.md
@@ -1,0 +1,3 @@
+# 在 AWS 上安装 Lain
+
+参考[青云](qingcloud.html)

--- a/adminmanual/install/qingcloud.md
+++ b/adminmanual/install/qingcloud.md
@@ -1,0 +1,94 @@
+# 在青云上安装 Lain
+
+## 机器选型
+
+- VPC ，关闭 DHCP
+- 使用 centos7.2 镜像创建 lain-01  节点
+- 修改 hostname。如 `hostname lain-01`(重新登录)
+- 编辑网络配置，写静态 ip 和 DNS。
+  ```sh
+  # @lain-01 
+  # vi /etc/sysconfig/network-scripts/ifcfg-eth0
+
+  DEVICE=eth0
+  BOOTPROTO=static
+  TYPE=Ethernet
+  NAME="System etho0"
+  BROADCAST=192.168.200.255
+  HWADDR=52:54:44:40:62:CC
+  IPADDR=192.168.200.21 # IP
+  IPV6INIT=yes
+  IPV6_AUTOCONF=yes
+  NETMASK=255.255.255.0
+  NETWORK=192.168.200.1
+  ONBOOT=yes
+  DNS1=10.16.40.3
+  DNS2=1.2.4.8
+  DOMAIN=pek2.qingcloud.com
+  GATEWAY=192.168.200.1
+  ```
+  然后重启 network，并测试。
+  ```sh
+  # @lain-01 
+  service network restart # 重启
+  curl www.douban.com # 测试一下是否通网
+  ```
+
+## Bootstrap
+
+```sh
+# @lain-01
+git clone git@github.com/laincloud/lain.git lain
+cd lain
+# DOMAIN 默认值是 lain.local
+./bootstrap -r registry.aliyuncs.com/laincloud --vip 192.168.200.201 --domain DOMAIN
+```
+
+## 配置 VPC 的公网路由器，端口转发
+
+转发公网ip的 80/443 端口到 `192.168.200.201` 这个 lain vip 的 80/443
+
+## Add node (optional)
+
+同 bootstrap 前设置 lain-01 一样，需要设置网络:
+
+```sh
+# @lain-02
+# vi /etc/sysconfig/network-scripts/ifcfg-eth0     写静态 ip 和 DNS
+
+DEVICE=eth0
+BOOTPROTO=static
+TYPE=Ethernet
+NAME="System etho0"
+BROADCAST=192.168.200.255
+HWADDR=52:54:34:96:76:55
+IPADDR=192.168.200.22  # IP
+IPV6INIT=yes
+IPV6_AUTOCONF=yes
+NETMASK=255.255.255.0
+NETWORK=192.168.200.1
+ONBOOT=yes
+DNS1=10.16.40.3
+DNS2=1.2.4.8
+DOMAIN=pek2.qingcloud.com
+GATEWAY=192.168.200.1
+```
+然后:
+```sh
+# @lain-02
+service network restart
+curl www.douban.com # 测试一下是否通网
+```
+
+```sh
+# @lain-01
+lainctl node add -p playbooks -q lain-02:192.168.200.22
+```
+
+> **注意**: 如果出现 ssh-copy-id  失败，可能需要把 `lain-01:/root/.ssh/lain.pub` 内容放到 `lain-02:/root/.ssh/authorized_keys`里，新增一行。
+> 当然原因可能是多样的，最有可能就是 lain-02 的 `/root/.ssh` 目录或者目录中的文件权限不对
+
+
+## Scale webrouter (optional)
+
+参见 [webrouter scale](../maintain/webrouter.html#scale)

--- a/adminmanual/maintain/README.md
+++ b/adminmanual/maintain/README.md
@@ -15,7 +15,7 @@ etcdctl set /lain/config/dnshijack/<domain.com> '<ip>'
 有多个需要劫持的地址则设则多次，设置完之后可以通过运行如下脚本会将相应配置放于`/etc/dnsmasq.d/proxy.conf`中：
 
 ```bash
-ansible-playbook -i /vagrant/playbooks/cluster -e "role=dns-hijack" /vagrant/playbooks/role.yaml
+ansible-playbook -i playbooks/cluster -e "role=dns-hijack" playbooks/role.yaml
 ```
 
 **注意:** 每次运行该脚本会将原有配置中内容覆盖掉，因此如果发生变动请务必记得修改etcd中的值，不要直接修改配置文件
@@ -26,7 +26,7 @@ ansible-playbook -i /vagrant/playbooks/cluster -e "role=dns-hijack" /vagrant/pla
 目前 Lain 中 swarm manager 使用的是伪HA策略，当 swarm 集群 出现主节点更换的情况下，需要管理员手动切换 swarm.lain 对应的 ip，可以使用如下命令：
 
 ```bash
-ansible-playbook -i /vagrant/playbooks/cluster -e "role=swarm-hijack" /vagrant/playbooks/role.yaml
+ansible-playbook -i playbooks/cluster -e "role=swarm-hijack" playbooks/role.yaml
 ```
 
 此命令会将 etcd 中 `/lain/config/swarm_manager_ip` 的 value 刷成 swarm.lain 对应的ip
@@ -51,7 +51,7 @@ clean-node 脚本支持同时清理多个节点， 使用 `--all` 参数可以�
 目前syslog 产生的日志文件（默认是`/var/log/messages`）较大，可能会导致对应目录容量吃紧，此脚本可以将 rsyslog 的日志文件存储位置到指定的其它地方去：
 
 ```bash
-ansible-playbook -i /vagrant/playbooks/cluster -e "role=rsyslog-relocate" -e "syslog_messages_location=/data/log/messages" /vagrant/playbooks/role.yaml
+ansible-playbook -i playbooks/cluster -e "role=rsyslog-relocate" -e "syslog_messages_location=/data/log/messages" playbooks/role.yaml
 ```
 
 **注意:** `syslog_messages_location`为迁移后日志文件的地址，不设置的话，地址不变
@@ -62,7 +62,7 @@ ansible-playbook -i /vagrant/playbooks/cluster -e "role=rsyslog-relocate" -e "sy
 如果 lain 某个节点出现了重启的情况（如断电了），需要有机制将 node 重新变成可调度状态。可执行以下命令：
 
 ```bash
-ansible-playbook -i /vagrant/playbooks/cluster -e "rsync_secrets=`cat /etc/rsyncd.secrets`" /vagrant/playbooks/site.yaml
+ansible-playbook -i playbooks/cluster -e "rsync_secrets=`cat /etc/rsyncd.secrets`" playbooks/site.yaml
 ```
 
 脚本运行完毕后可以通过运行 `docker -H :2376 ps | grep calico` 监测对应节点是否启动

--- a/adminmanual/maintain/backup.md
+++ b/adminmanual/maintain/backup.md
@@ -5,7 +5,7 @@ backup目前仅支持MooseFS这一种后端存储，所以，在使用backupd前
 ## 初始化
 
 ```
-ansible-playbook -i /vagrant/playbooks/cluster -e "role=backupd" /vagrant/playbooks/role.yaml
+ansible-playbook -i playbooks/cluster -e "role=backupd" playbooks/role.yaml
 ```
 
 初始化backupd后，再add-node添加节点，新node都会自动启动backupd服务。

--- a/adminmanual/maintain/etcd.md
+++ b/adminmanual/maintain/etcd.md
@@ -30,14 +30,14 @@ Lain支持手动修改各个node上etcd的mode，即把一个etcd-proxy变成etc
 ### proxy 变 member
 ```bash
 etcdctl set /lain/nodes/etcd-members/node2:192.168.77.22:22 192.168.77.22
-ansible-playbook -i /vagrant/playbooks/cluster -e role=etcd  /vagrant/playbooks/role.yaml
+ansible-playbook -i playbooks/cluster -e role=etcd  playbooks/role.yaml
 ```
 
 ### member 变 proxy
 
 ```bash
 etcdctl rm /lain/nodes/etcd-members/node2:192.168.77.22:22
-ansible-playbook -i /vagrant/playbooks/cluster -e role=etcd  /vagrant/playbooks/role.yaml
+ansible-playbook -i playbooks/cluster -e role=etcd  playbooks/role.yaml
 ```
 
 ### cluster unhealth

--- a/adminmanual/maintain/moosefs.md
+++ b/adminmanual/maintain/moosefs.md
@@ -34,7 +34,7 @@ etcdctl set /lain/nodes/moosefs-metalogger/node2:192.168.77.22:22 node2:192.168.
 ### 2. 执行ansible
 
 ```sh
-ansible-playbook -i /vagrant/playbooks/cluster -e "role=moosefs-build" /vagrant/playbooks/role.yaml
+ansible-playbook -i playbooks/cluster -e "role=moosefs-build" playbooks/role.yaml
 ```
 
 该命令会根据etcd中的配置，在指定的节点上启动moosefs server.
@@ -45,7 +45,7 @@ ansible-playbook -i /vagrant/playbooks/cluster -e "role=moosefs-build" /vagrant/
 有了 MooseFS Service 后，使用以下命令,将`/mfs`挂载到MooseFS。 此后再通过`add-node`新增节点，新节点的`/mfs`也会被自动挂载上
 
 ```sh
-ansible-playbook -i /vagrant/playbooks/cluster -e "role=moosefs" /vagrant/playbooks/role.yaml
+ansible-playbook -i playbooks/cluster -e "role=moosefs" playbooks/role.yaml
 ```
 
 ## Register On MooseFS
@@ -58,7 +58,7 @@ bootstrap完后，Registry默认是使用local filesystem作为backend，这也�
 
 
 ```bash
-ansible-playbook -i /vagrant/playbooks/cluster -e "role=registry-moosefs" /vagrant/playbooks/role.yaml
+ansible-playbook -i playbooks/cluster -e "role=registry-moosefs" playbooks/role.yaml
 ```
 
 **注1:** 该操作执行过程中，Registry是无法对外提供服务的。因为我们需要将已有的数据拷贝到MooseFS上，这需要花一些时间。

--- a/adminmanual/maintain/swarm.md
+++ b/adminmanual/maintain/swarm.md
@@ -21,11 +21,11 @@ etcdctl get /docker/swarm/leader
 
 # 增加一个manager
 etcdctl set /lain/nodes/swarm-managers/node2:192.168.77.22:22 192.168.77.22
-ansible-playbook -i /vagrant/playbooks/cluster -e role=swarm  /vagrant/playbooks/role.yaml
+ansible-playbook -i playbooks/cluster -e role=swarm  playbooks/role.yaml
 
 # 删除一个manager
 etcdctl rm /lain/nodes/swarm-managers/node2:192.168.77.22:22
-ansible-playbook -i /vagrant/playbooks/cluster -e role=swarm  /vagrant/playbooks/role.yaml
+ansible-playbook -i playbooks/cluster -e role=swarm  playbooks/role.yaml
 ```
 
 ## swarm agent

--- a/adminmanual/maintain/webrouter.md
+++ b/adminmanual/maintain/webrouter.md
@@ -1,14 +1,15 @@
 # Webrouter
 
-webrouter是所有lain app的入口，包括layer1层的registry和console等。基于Tengine实现。
+webrouter 是所有 lain app 的入口，包括 layer1 层的 registry 和 console 等。基于 Tengine 实现。
 
 ## Scale
 
-webrouter可以启多个instance来实现High Avaliable。 由于webrouter的特殊身份，无法像普通的lain app简单的scale，而且其在scale过程中所有的web类型的lain app都可能会出现短暂的无法访问。
+webrouter 可以启多个 instance 来实现 High Avaliable。 由于 webrouter 的特殊身份，无法像普通的 lain app 简单的 scale，而且其在 scale 过程中所有的 web 类型的 lain app 都可能会出现短暂的无法访问。
 
-因 swarm 是动态决定一个 container 部署到哪台机器，而 webrouter 在启动之前是需要配置文件存在的。因此我们需要确保集群的所有 node 上有一份 webrouter 的配置，以确保 swarm 无论在哪台机器上启动 webrouter ，能都能正常工作。
+因 swarm 是动态决定一个 container 部署到哪台机器，而 webrouter 在启动之前是需要配置文件存在的。因此我们需要确保集群的所有 node 上有一份 webrouter 的配置，进而确保 swarm 无论在哪台机器上启动 webrouter ，能都能正常工作。
 
-或者，我们可以通过 `docker -H swarm.lain:2376 info` 查看各个节点的资源使用情况，预测下 webrouter 会被部署到哪个节点上。
+或者，也可以通过 `docker -H swarm.lain:2376 info` 查看各个节点的资源使用情况，预测下 webrouter 会被部署到哪个节点上。
+
 
 具体操作步骤如下:
 
@@ -18,6 +19,7 @@ webrouter可以启多个instance来实现High Avaliable。 由于webrouter的特
    mkdir -p /data/lain/volumes/webrouter/webrouter.worker.worker/2/
    rsync -az --password-file  /tmp/pass rsync://lain@BOOTSTRAP_NODE/lain_volume/webrouter/webrouter.worker.worker/1/ /data/lain/volumes/webrouter/webrouter.worker.worker/2/
    ```
+   **注**: *以上命令中的目录的中的数字，实为 instance number。此处为 2；假如我们扩容到 3 个，则还需要为 3 号实例准备一份同样数据。*
 
 2. 利用swarm，在所有node上pull webrouter image，确保每个节点上都有webrouter image
    ```sh
@@ -27,6 +29,8 @@ webrouter可以启多个instance来实现High Avaliable。 由于webrouter的特
    ```sh
    lain scale -n NUMBER PHASE worker
    ```
+
+*所以，webrouter 会的 HA 建议尽可能早做，如果集群的规模扩大，scale 起来也可能会麻烦些。*
 
 ## 故障排除
 

--- a/adminmanual/recovery.md
+++ b/adminmanual/recovery.md
@@ -41,7 +41,7 @@
 - master/member node
     - `etcdctl member list`
     - `etcdctl cluster-health`
-- proxy node 
+- proxy node
     - 确认是 proxy 节点
         - `systemctl stop etcd`
         - `rm -rf /var/etcd/$(hostname)`
@@ -85,9 +85,9 @@
 
 - `ansible -i ~/lain/playbooks/cluster all -m shell -a 'docker ps |grep calico'`
 - `ansible -i ~/lain/playbooks/cluster all -m shell -a 'docker start calico-node'`
-- `ansible -i ~/lain/playbooks/cluster all -m shell -a 'docker -H :2377 ps |grep calico'`
+- `ansible -i ~/lain/playbooks/cluster all -m shell -a 'docker ps |grep calico'`
 - 出现问题可以手动删除容器之后重新部署
-- docker -H :2377 ps 查看状态
+- docker ps 查看状态
 
 ### swarm
 
@@ -104,13 +104,23 @@
 - `ansible -i ~/lain/playbooks/cluster all -m shell -a 'systemctl restart networkd'`
 - `ansible -i ~/lain/playbooks/cluster all -m shell -a 'systemctl status networkd'`
 
-### tinydns- `ansible -i ~/lain/playbooks/cluster all -m shell -a 'docker ps -a|grep tinydns'`- `docker -H :2377 start tinydns.worker.worker`- `etcdctl get /lain/config/vips/10.106.170.203` (需要一个查询 app vip 的工具?)- VIP `ip addr show dev eth0`
+### tinydns
 
-1. deployd- `ansible -i ~/lain/playbooks/cluster all -m shell -a 'docker ps -a|grep deploy'`- `docker -H :2377 start deploy.web.web.v0-i1-d0`- `docker exec deploy.web.web.v0-i1-d0 ip addr`- `etcdctl get /lain/deployd/leader`- 等待 deployd 拉起剩余组件(需要查看 deploy 的工具?)
+- `ansible -i ~/lain/playbooks/cluster all -m shell -a 'docker ps -a|grep tinydns'`
+- `docker start tinydns.worker.worker`
+- `etcdctl get /lain/config/vips/10.106.170.203`
+- VIP `ip addr show dev eth0`
 
-1. lvault 解锁- 运行两次 unseal.sh 脚本- `sh ~/unseal.sh yxapp.xyz`
+### deployd
 
-1. 检查git/wiki是否运行正常- http://gitlab.yxapp.xyz- http://wiki.yxapp.xyz
+- `etcdctl ls /lain/nodes/deployd` 查看 deployd 运行在哪个节点。
+- 登录到节点上 `systemctl start deployd`
 
-1. 恢复 rebellion- `ansible -i ~/lain/playbooks/cluster all -m shell -a 'docker start rebellion.service'`
+### lvault
+
+- 解锁lvault, 运行两次 unseal.sh 脚本: `sh ~/unseal.sh DOMAIN`
+
+### rebellion
+
+- `ansible -i ~/lain/playbooks/cluster all -m shell -a 'systemctl start rebellion.service'`
 


### PR DESCRIPTION
1. 青云安装
2. maintain 里对 `/vagrant` 目录的使用都去掉了
3. admin recovery 教程里失效的内容修复
