### PR TITLE
proc.cmd 和 proc.entrypoint 支持类似于 Dockerfile 的 exec form 和 shell form 的说明

### DIFF
--- a/quickstart/install.md
+++ b/quickstart/install.md
@@ -35,7 +35,7 @@ vagrant ssh node1
 ```
 [vagrant@node1 ~]$ sudo su -
 [vagrant@node1 ~]$ cd /vagrant
-[vagrant@node1 vagrant]# ./bootstrap -r registry.aliyuncs.com/laincloud --vip=192.168.77.201 --node-ip=192.168.77.21
+[vagrant@node1 vagrant]# ./bootstrap -r registry.aliyuncs.com/laincloud --vip=192.168.77.201
 ```
 
 初始化需要至少 20 分钟，取决于网络速度
@@ -115,12 +115,3 @@ sudo lainctl node add -p playbooks -q {{ hostname }}:{{ hostname }}
 
 ### add-node ssh-copy-id 失败
 如果出现 ssh-copy-id  失败，可能需要把 `node1:/root/.ssh/lain.pub` 内容放到 `node2:/root/.ssh/authorized_keys`里，新增一行。当然原因可能是多样的，最有可能就是 lain-02 的 `/root/.ssh` 目录或者目录中的文件权限不对
-
-### add-node `wait for etcd to be healthy` 失败
-
-如果出现 `wait for etcd to be healthy` 失败，很有可能是新节点无法访问老节点。
-出现这种情况的原因是 `CentOS 7` 采用了 [predictable network interface
-name](https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/)
-，不再使用 `eth0`、`eth1` 等命名网卡；而 `bootstrap` 时默认寻找 `eth1`，找不到时就会使用
-默认网卡，但有时候默认网卡不一定能从外部访问。所以请在
-`bootstrap` 时加上 `--net-interface={{ net_interface }}` 参数，明确指定一个能被其他节点访问到的 `{{ net_interface }}`。

--- a/quickstart/install.md
+++ b/quickstart/install.md
@@ -35,7 +35,7 @@ vagrant ssh node1
 ```
 [vagrant@node1 ~]$ sudo su -
 [vagrant@node1 ~]$ cd /vagrant
-[vagrant@node1 ~]$ sudo ./bootstrap -r registry.aliyuncs.com/laincloud --vip=192.168.77.201
+[vagrant@node1 vagrant]$ ./bootstrap -r registry.aliyuncs.com/laincloud --vip=192.168.77.201 --node-ip=192.168.77.21
 ```
 
 初始化需要至少 20 分钟，取决于网络速度
@@ -115,3 +115,13 @@ sudo lainctl node add -p playbooks -q {{ hostname }}:{{ hostname }}
 
 ### add-node ssh-copy-id 失败
 如果出现 ssh-copy-id  失败，可能需要把 `node1:/root/.ssh/lain.pub` 内容放到 `node2:/root/.ssh/authorized_keys`里，新增一行。当然原因可能是多样的，最有可能就是 lain-02 的 `/root/.ssh` 目录或者目录中的文件权限不对
+
+### add-node `wait for etcd to be healthy` 失败
+
+如果出现 `wait for etcd to be healthy` 失败，很有可能是新节点无法访问老节点。
+出现这种情况的原因是 `CentOS 7` 采用了 [predictable network interface
+name](https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/)
+，而 `bootstrap` 时默认寻找 `eth1`，在新命名规则下没有 `eth1`，`LAIN` 就会使用
+默认 `ip` 作为 `node-ip`，但有时，默认 `ip` 不一定能从外部访问。所以请在
+`bootstrap` 时加上 `--node-ip={{ node_ip }}` 参数，明确指定一个能被其他节点访
+问到的 `node-ip`。

--- a/quickstart/install.md
+++ b/quickstart/install.md
@@ -122,5 +122,5 @@ sudo lainctl node add -p playbooks -q {{ hostname }}:{{ hostname }}
 出现这种情况的原因是 `CentOS 7` 采用了 [predictable network interface
 name](https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/)
 ，不再使用 `eth0`、`eth1` 等命名网卡；而 `bootstrap` 时默认寻找 `eth1`，找不到时就会使用
-默认 `ip` 作为 `node-ip`，但有时候默认 `ip` 不一定能从外部访问。所以请在
-`bootstrap` 时加上 `--node-ip={{ node_ip }}` 参数，明确指定一个能被其他节点访问到的 `node-ip`。
+默认网卡，但有时候默认网卡不一定能从外部访问。所以请在
+`bootstrap` 时加上 `--net-interface={{ net_interface }}` 参数，明确指定一个能被其他节点访问到的 `{{ net_interface }}`。

--- a/quickstart/install.md
+++ b/quickstart/install.md
@@ -35,7 +35,7 @@ vagrant ssh node1
 ```
 [vagrant@node1 ~]$ sudo su -
 [vagrant@node1 ~]$ cd /vagrant
-[vagrant@node1 vagrant]$ ./bootstrap -r registry.aliyuncs.com/laincloud --vip=192.168.77.201 --node-ip=192.168.77.21
+[vagrant@node1 vagrant]# ./bootstrap -r registry.aliyuncs.com/laincloud --vip=192.168.77.201 --node-ip=192.168.77.21
 ```
 
 初始化需要至少 20 分钟，取决于网络速度
@@ -121,7 +121,6 @@ sudo lainctl node add -p playbooks -q {{ hostname }}:{{ hostname }}
 如果出现 `wait for etcd to be healthy` 失败，很有可能是新节点无法访问老节点。
 出现这种情况的原因是 `CentOS 7` 采用了 [predictable network interface
 name](https://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/)
-，而 `bootstrap` 时默认寻找 `eth1`，在新命名规则下没有 `eth1`，`LAIN` 就会使用
-默认 `ip` 作为 `node-ip`，但有时，默认 `ip` 不一定能从外部访问。所以请在
-`bootstrap` 时加上 `--node-ip={{ node_ip }}` 参数，明确指定一个能被其他节点访
-问到的 `node-ip`。
+，不再使用 `eth0`、`eth1` 等命名网卡；而 `bootstrap` 时默认寻找 `eth1`，找不到时就会使用
+默认 `ip` 作为 `node-ip`，但有时候默认 `ip` 不一定能从外部访问。所以请在
+`bootstrap` 时加上 `--node-ip={{ node_ip }}` 参数，明确指定一个能被其他节点访问到的 `node-ip`。

--- a/usermanual/lainyaml.md
+++ b/usermanual/lainyaml.md
@@ -42,7 +42,6 @@ proc.{PROC_NAME}:           # 定义一个 proc, 定义 web 时，可以只用 w
                             # - cmd: ["executable","param1","param2"] (exec form)
                             # - cmd: ["param1","param2"] (as default parameters to entrypoint)
                             # - cmd: command param1 param2 (shell form)
-
   num_instances: 1          # 部署时 proc 的个数，默认为 1
   https_only: true          # 针对 web 类型，默认为false, 是否只允许 https 访问
   healthcheck: '/url'       # 针对 web 类型，提供该 url 给 tengine 进行健康检查

--- a/usermanual/lainyaml.md
+++ b/usermanual/lainyaml.md
@@ -32,7 +32,14 @@ proc.{PROC_NAME}:           # 定义一个 proc, 定义 web 时，可以只用 w
   user: root                # 默认为 root，还可以定义一些 release image 中存在的 user，比如 nobody 等
   type: worker              # 默认为 worker，还包括 web, portal
   image: {PROC_IMAGE}       # 默认为 app image，也可以进行自定义
-  cmd: {PROC_CMD}           # 启动 proc 时定义的命令
+  entrypoint: {PROC_ENTRYPOINT}   # 启动 proc 时的入口点，默认为 `/bin/sh -c`，支持类似于 `Dockerfile` 中的 `ENTRYPOINT` 的两种格式：
+                                  # - `entrypoint: ["executable","param1","param2"]` (exec form)
+                                  # - `entrypoint: command param1 param2` (shell form)
+  cmd: {PROC_CMD}           # 启动 proc 时定义的命令，`entrypoint` 与 `cmd` 必须至少写一个，支持类似于 `Dockerfile` 中的 `CMD` 的三种格式：
+                            # - `cmd: ["executable","param1","param2"]` (exec form)
+                            # - `cmd: ["param1","param2"]` (as default parameters to entrypoint)
+                            # - `cmd: command param1 param2` (shell form)
+
   num_instances: 1          # 部署时 proc 的个数，默认为 1
   https_only: true          # 针对 web 类型，默认为false, 是否只允许 https 访问
   healthcheck: '/url'       # 针对 web 类型，提供该 url 给 tengine 进行健康检查

--- a/usermanual/lainyaml.md
+++ b/usermanual/lainyaml.md
@@ -32,13 +32,16 @@ proc.{PROC_NAME}:           # 定义一个 proc, 定义 web 时，可以只用 w
   user: root                # 默认为 root，还可以定义一些 release image 中存在的 user，比如 nobody 等
   type: worker              # 默认为 worker，还包括 web, portal
   image: {PROC_IMAGE}       # 默认为 app image，也可以进行自定义
-  entrypoint: {PROC_ENTRYPOINT}   # 启动 proc 时的入口点，默认为 `/bin/sh -c`，支持类似于 `Dockerfile` 中的 `ENTRYPOINT` 的两种格式：
-                                  # - `entrypoint: ["executable","param1","param2"]` (exec form)
-                                  # - `entrypoint: command param1 param2` (shell form)
-  cmd: {PROC_CMD}           # 启动 proc 时定义的命令，`entrypoint` 与 `cmd` 必须至少写一个，支持类似于 `Dockerfile` 中的 `CMD` 的三种格式：
-                            # - `cmd: ["executable","param1","param2"]` (exec form)
-                            # - `cmd: ["param1","param2"]` (as default parameters to entrypoint)
-                            # - `cmd: command param1 param2` (shell form)
+  entrypoint: {PROC_ENTRYPOINT}   # 启动 proc 时的入口点，默认为 /bin/sh -c，支
+                                  # 持类似于 Dockerfile 中的 ENTRYPOINT 的两种
+                                  # 格式：
+                                  # - entrypoint: ["executable","param1","param2"] (exec form)
+                                  # - entrypoint: command param1 param2 (shell form)
+  cmd: {PROC_CMD}           # 启动 proc 时定义的命令，entrypoint 与 cmd 必须至
+                            # 少写一个，支持类似于 Dockerfile 中的 CMD 的三种格式：
+                            # - cmd: ["executable","param1","param2"] (exec form)
+                            # - cmd: ["param1","param2"] (as default parameters to entrypoint)
+                            # - cmd: command param1 param2 (shell form)
 
   num_instances: 1          # 部署时 proc 的个数，默认为 1
   https_only: true          # 针对 web 类型，默认为false, 是否只允许 https 访问


### PR DESCRIPTION
# 起因

在合并[这个更改](https://github.com/laincloud/lain-sdk/pull/4)之后，`proc.cmd` 支持三种形式：
- `cmd: ["executable","param1","param2"]` (exec form)
- `cmd: ["param1","param2"]` (as default parameters to ENTRYPOINT)
- `cmd: command param1 param2` (shell form)

同时，`proc.entrypoint` 支持两种形式：
- `entrypoint: ["executable","param1","param2"]` (exec form)
- `entrypoint: command param1 param2` (shell form)

所以，在此处更改了 `lain.yaml` 文件的说明。

> 同时，我修改了 `bootstrap` 命令的一处细节~

请各位审核~
